### PR TITLE
cleanup and css actions

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import "antd/dist/antd.css";
 const CONTRIBUTORS = {
   key: "",
   name: "",
-  defaultValue: 0,
+  defaultValue: "",
   value: "",
   isReturned: false,
   contributorIsEditable: true
@@ -38,7 +38,7 @@ class App extends Component {
           {
             key: "",
             name: "",
-            defaultValue: 0,
+            defaultValue: "",
             value: "",
             isReturned: false,
             contributorIsEditable: true
@@ -56,14 +56,6 @@ class App extends Component {
     notReturned: 0
   };
 
-  // inputValidation = (event) => {
-
-  //   if ((event.target.value).length === 0) {
-
-  //   }
-  // }
-
-  //mapping contributors array and sum default contributors values to notReturned in state
   sharedAmountManipulation = index => {
     const transaction = [...this.state.transactions];
     const oldSharedAmount = transaction[index].sharedAmount;
@@ -92,7 +84,6 @@ class App extends Component {
     this.setState({ notReturned: Number(newNotReturned.toFixed(2)) });
   };
 
-  //calculate actual value for each contributor regard to transaction value
   onContributorValue = (index, contributorIndex) => {
     const transaction = [...this.state.transactions];
 
@@ -122,7 +113,6 @@ class App extends Component {
     this.setState({ transactions: transaction });
   };
 
-  //change contributor if value was returned and update notReturned state value
   onReturnedContributor = (index, contributorIndex) => {
     const transaction = [...this.state.transactions];
     const oldSharedAmount = transaction[index].sharedAmount;
@@ -265,13 +255,8 @@ class App extends Component {
       return contributor.defaultValue;
     });
     const totalTransactionValue = arr.reduce((a, b) => a + b);
-    // const firstContributorValue =
-    //   transaction[index].transactionContributors[0].value;
 
-    if (
-      totalTransactionValue > transaction[index].amount
-      // firstContributorValue > transaction[index].amount
-    ) {
+    if (totalTransactionValue > transaction[index].amount) {
       return;
     } else {
       transaction[index].transactionContributors.unshift(defaultContributor);
@@ -366,9 +351,14 @@ class App extends Component {
     }
   };
 
-  onBlurTransactions = transaction => {};
-
   render() {
+    let addButtonState = false;
+    if (
+      String(this.state.transactions[0].amount).length < 1 ||
+      this.state.transactions[0].amount === 0
+    ) {
+      addButtonState = true;
+    }
     return (
       <React.Fragment>
         <Layout
@@ -376,6 +366,7 @@ class App extends Component {
           budgetChange={this.onBudgetChange}
           budget={this.state.budget}
           notReturned={this.state.notReturned}
+          addButtonState={addButtonState}
         >
           <TransactionsScreen
             handleDelete={this.handleDelete}

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -11,13 +11,19 @@ const layout = props => (
       notReturned={props.notReturned}
     />
     <div className={classes.Content}>{props.children}</div>{" "}
-    <Affix style={{ position: "fixed", bottom: "20px", right: "20px" }}>
+    <Affix style={{ position: "fixed", bottom: "35px", right: "20px" }}>
       <Button
         shape="circle"
         type="primary"
         icon="plus"
         onClick={props.addTransaction}
         size="large"
+        style={{
+          width: "55px",
+          height: "55px",
+          fontSize: "30px"
+        }}
+        disabled={props.addButtonState}
       />
     </Affix>
   </React.Fragment>

--- a/src/components/Layout/Layout.module.css
+++ b/src/components/Layout/Layout.module.css
@@ -1,8 +1,3 @@
 .Content {
   padding-top: 60px;
 }
-.AddButton {
-  position: fixed;
-  right: 0;
-  bottom: 0;
-}

--- a/src/components/Layout/Menu/Menu.js
+++ b/src/components/Layout/Menu/Menu.js
@@ -9,6 +9,7 @@ const menu = props => (
         placeholder="Your budget"
         className={classes.input}
         onBlur={props.budgetChange}
+        max={99999}
       />
 
       <Statistic

--- a/src/components/Transaction/Contributors/Contributor/Contributor.js
+++ b/src/components/Transaction/Contributors/Contributor/Contributor.js
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import classes from "./Contributor.module.css";
-import EditButton from "./EditButton/EditButton";
 import ReturnedButton from "./ReturnedButton/ReturnedButton";
 import DeleteButton from "./DeleteButton/DeleteButton";
 import { Button, Input, Table } from "antd";
@@ -30,16 +29,23 @@ class Contributor extends Component {
       )
     },
     {
-      title: "Action",
+      title: null,
       dataIndex: "action",
-      render: (text, record) => (
-        <DeleteButton
-          contributorIndex={record.key}
-          toggle={this.props.toggle}
-          onDeleteContributor={this.props.onDeleteContributor}
-          index={this.props.index}
-        />
-      )
+      render: (text, record) => {
+        if (record.isReturned) {
+          return;
+        } else {
+          return (
+            <DeleteButton
+              contributorIndex={record.key}
+              toggle={this.props.toggle}
+              onDeleteContributor={this.props.onDeleteContributor}
+              index={this.props.index}
+              isReturned={record.isReturned}
+            />
+          );
+        }
+      }
     }
   ];
 
@@ -98,6 +104,8 @@ class Contributor extends Component {
                 this.props.onInputContributor(event, index, contributorIndex)
               }
               style={{ width: "70%" }}
+              maxLength={10}
+              allowClear
             />
           </Input.Group>
           {addButton}
@@ -125,20 +133,7 @@ class Contributor extends Component {
       );
     }
 
-    return (
-      <React.Fragment>
-        {extension}
-        {/* <EditButton
-          contributorIsEditable={this.props.contributorIsEditable}
-          contributorIndex={contributorIndex}
-          onEditContributor={this.props.onEditContributor}
-          index={index}
-          isEditable={isEditable}
-          toggle={toggle}
-          isReturned={isReturned}
-        /> */}
-      </React.Fragment>
-    );
+    return <React.Fragment>{extension}</React.Fragment>;
   }
 }
 

--- a/src/components/Transaction/Contributors/Contributor/DeleteButton/DeleteButton.js
+++ b/src/components/Transaction/Contributors/Contributor/DeleteButton/DeleteButton.js
@@ -1,22 +1,24 @@
 import React, { Component } from "react";
-import { Icon } from "antd";
+import { Icon, Popconfirm } from "antd";
 
 class DeleteButton extends Component {
   render() {
     let deleteButton = null;
     if (this.props.contributorIndex !== 0 && this.props.toggle) {
       deleteButton = (
-        <Icon
-          type="delete"
-          theme="twoTone"
-          twoToneColor="red"
-          onClick={() =>
+        <Popconfirm
+          title="Sure to delete?"
+          onConfirm={() =>
             this.props.onDeleteContributor(
               this.props.index,
               this.props.contributorIndex
             )
           }
-        />
+          placement="topRight"
+          arrowPointAtCenter
+        >
+          <Icon type="delete" theme="twoTone" twoToneColor="red" />
+        </Popconfirm>
       );
     }
     return <React.Fragment>{deleteButton}</React.Fragment>;

--- a/src/components/Transaction/Contributors/Contributor/EditButton/EditButton.js
+++ b/src/components/Transaction/Contributors/Contributor/EditButton/EditButton.js
@@ -1,17 +1,8 @@
 import React, { Component } from "react";
-import classes from "./EditButton.module.css";
 import { Icon } from "antd";
 
 class EditButton extends Component {
   render() {
-    const editStr = this.props.contributorIsEditable ? "accept" : "edit";
-    // let editStr = "edit";
-    // const editArr = [];
-    // if (this.props.contributorIsEditable) {
-    //   editArr.push(classes.Accept);
-    //   editStr = "accept";
-    // }
-
     let editButton = null;
     if (
       this.props.contributorIndex !== 0 &&
@@ -29,7 +20,6 @@ class EditButton extends Component {
               this.props.contributorIndex
             )
           }
-          // className={editArr.join(" ")}
         />
       );
     }
@@ -45,7 +35,6 @@ class EditButton extends Component {
               this.props.contributorIndex
             )
           }
-          // className={editArr.join(" ")}
         />
       );
     }

--- a/src/components/Transaction/Contributors/Contributor/ReturnedButton/ReturnedButton.js
+++ b/src/components/Transaction/Contributors/Contributor/ReturnedButton/ReturnedButton.js
@@ -5,7 +5,7 @@ import { Switch } from "antd";
 class ReturnedButton extends Component {
   render() {
     const returnedCol = this.props.isReturned ? "#52c41a" : "red";
-    const returnedStr = this.props.isReturned ? "Returned" : "Not Returned";
+    const returnedStr = this.props.isReturned ? "Returned" : "Pending";
 
     let returnedButton = null;
     if (

--- a/src/components/Transaction/DeleteButton/DeleteButton.js
+++ b/src/components/Transaction/DeleteButton/DeleteButton.js
@@ -1,20 +1,25 @@
 import React, { Component } from "react";
 import classes from "./DeleteButton.module.css";
-import { Icon } from "antd";
+import { Icon, Popconfirm } from "antd";
 
 class DeleteButton extends Component {
   render() {
     let deleteButton = null;
     if (this.props.index !== 0) {
       deleteButton = (
-        <Icon
-          type="close-circle"
-          theme="twoTone"
-          twoToneColor="red"
-          onClick={this.props.deleteTransaction}
-          className={classes.DeleteButton}
-          style={{ fontSize: "15px", marginLeft: "5px" }}
-        />
+        <Popconfirm
+          title="Sure to delete?"
+          onConfirm={this.props.deleteTransaction}
+          placement="topRight"
+          arrowPointAtCenter
+        >
+          <Icon
+            type="close-circle"
+            theme="twoTone"
+            twoToneColor="red"
+            className={classes.DeleteButton}
+          />
+        </Popconfirm>
       );
     }
     return <React.Fragment>{deleteButton}</React.Fragment>;

--- a/src/components/Transaction/DeleteButton/DeleteButton.module.css
+++ b/src/components/Transaction/DeleteButton/DeleteButton.module.css
@@ -1,0 +1,4 @@
+.DeleteButton {
+  font-size: 18px;
+  margin-left: 6px;
+}

--- a/src/components/Transaction/EditButton/EditButton.js
+++ b/src/components/Transaction/EditButton/EditButton.js
@@ -4,13 +4,8 @@ import { Icon } from "antd";
 
 class EditButton extends Component {
   render() {
-    const editArr = this.props.isEditable ? [classes.Accept] : [];
-    const editStr = this.props.isEditable ? "accept" : "edit";
-    // let editStr = "edit";
-    // if (this.props.isEditable) {
-    //   editArr.push(classes.Accept);
-    //   editStr = "accept";
-    // }
+    // const editArr = this.props.isEditable ? [classes.Accept] : [];
+    // const editStr = this.props.isEditable ? "accept" : "edit";
 
     let editButton = null;
     if (this.props.index !== 0) {
@@ -20,7 +15,6 @@ class EditButton extends Component {
           theme="twoTone"
           onClick={this.props.onEdit}
           className={classes.EditButton}
-          style={{ fontSize: "15px" }}
         />
       );
     }
@@ -32,7 +26,6 @@ class EditButton extends Component {
           twoToneColor="#52c41a"
           onClick={this.props.onEdit}
           className={classes.EditButton}
-          style={{ fontSize: "15px" }}
         />
       );
     }

--- a/src/components/Transaction/EditButton/EditButton.module.css
+++ b/src/components/Transaction/EditButton/EditButton.module.css
@@ -1,0 +1,3 @@
+.EditButton {
+  font-size: 18px;
+}

--- a/src/components/Transaction/Transaction.js
+++ b/src/components/Transaction/Transaction.js
@@ -29,6 +29,7 @@ class Transaction extends Component {
             value={this.props.description}
             onChange={this.props.descriptionInputHandler}
             style={{ width: "70%" }}
+            allowClear
           />
         </Input.Group>
       </div>
@@ -63,7 +64,7 @@ class Transaction extends Component {
         {line}
         <TransactionDate date={this.props.date} />
         <div className={classes.Transaction}>
-          <div style={{ float: "right" }}>
+          <div className={classes.Actions}>
             <Editbutton
               isEditable={this.props.isEditable}
               onEdit={this.props.onEdit}

--- a/src/components/Transaction/Transaction.module.css
+++ b/src/components/Transaction/Transaction.module.css
@@ -1,5 +1,5 @@
 .Transaction {
-  width: 88%;
+  width: 98%;
   max-width: 500px;
   min-height: 80px;
   border: 1px solid #1890ff;
@@ -9,18 +9,25 @@
   box-shadow: 0 2px 3px #188fffaf;
 }
 
-/* @media (min-width: 1200px) and (min-height: 400px) {
-  .Transaction {
-    width: 350px;
-    height: 300px;
-  }
-} */
+.Actions {
+  display: flex;
+  width: 100%;
+  justify-content: flex-end;
+  margin-bottom: 8px;
+}
 
-@media (max-width: 320px) and (min-height: 400px) {
+@media (min-width: 360px) {
   .Transaction {
-    width: 98%;
+    width: 92%;
   }
 }
+
+@media (min-width: 361px) {
+  .Transaction {
+    width: 88%;
+  }
+}
+
 .Input {
   margin-bottom: 10px;
   display: flex;

--- a/src/containers/TransactionsScreen/TransactionsScreen.js
+++ b/src/containers/TransactionsScreen/TransactionsScreen.js
@@ -6,7 +6,6 @@ const TransactionsScreen = props => {
   const transactions = currentTransaction.map((transaction, index) => {
     return (
       <Transaction
-        handleDelete={props.handleDelete}
         amount={transaction.amount}
         description={transaction.description}
         toggle={transaction.toggle}


### PR DESCRIPTION
Zmieniono: 
- poprawiono stylowanie przycisków akcji 
- usunięto możliwość usuwania zwróconego kontrybutora
- usunięto nazwę tytułową kolumny actions co pozwoliło zaoszczędzić miejsce
- poprawiono wyświetlanie na mniejszych urządzeniach
- przycisk odpowiedzialny za dodawanie transakcji jest teraz wyłączony jeśli nie wpiszemy nic w pole amount
- inne drobne poprawki